### PR TITLE
Fix org.dockingframes:docking-frames-common dependence

### DIFF
--- a/gui-framework-core/build.gradle
+++ b/gui-framework-core/build.gradle
@@ -10,7 +10,7 @@ repositories {
 dependencies {
     implementation project(':gui-framework-common')
     implementation project(':common')
-    implementation 'org.dockingframes:docking-frames-common:1.1.2-SNAPSHOT'
+    implementation 'org.dockingframes:docking-frames-common:1.1.1'
     implementation 'javax.help:javahelp:2.0.05'
     testImplementation group: 'junit', name: 'junit', version: '4.11'
 }


### PR DESCRIPTION
The org.dockingframes:docking-frames-common:1.1.2-SNAPSHOT dependency is no longer available in the MAVEN repository, so I changed it to org.dockingframes:docking-frames-common:1.1.1 to be able to build.